### PR TITLE
backend-ulc-response to backend

### DIFF
--- a/src/main/java/ulcrs/data/DataFetch.java
+++ b/src/main/java/ulcrs/data/DataFetch.java
@@ -47,21 +47,35 @@ class DataFetch {
 
         try
         {
-            // Initialize HTTP request
-            URL url = new URL(DROP_IN_REQUEST_URL);
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod(DROP_IN_REQUEST_REQUEST_TYPE);
-            connection.setRequestProperty(CONTENT_TYPE, DROP_IN_REQUEST_CONTENT_TYPE);
-            connection.setRequestProperty(COOKIE, cookie);
-            connection.setRequestProperty(CONTENT_LENGTH, Integer.toString(DROP_IN_REQUEST_DATA.getBytes().length));
-            connection.setRequestProperty(CONTENT_LANGUAGE, DROP_IN_REQUEST_CONTENT_LANGUAGE);
-            connection.setUseCaches(false);
-            connection.setDoOutput(true);
+            // Note:
+            // The below commented code is the code required to hit the ULC endpoint to get ULC data.
+            //
+            // For now, we are accessing a json file on the ULC server directly to get this ULC data since this file
+            // has the necessary course requirement information, while the endpoint does not yet.
 
-            // Send request
-            DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-            wr.writeBytes(DROP_IN_REQUEST_DATA);
-            wr.close();
+//            // Initialize HTTP request
+//            URL url = new URL(DROP_IN_REQUEST_URL);
+//            connection = (HttpURLConnection) url.openConnection();
+//            connection.setRequestMethod(DROP_IN_REQUEST_REQUEST_TYPE);
+//            connection.setRequestProperty(CONTENT_TYPE, DROP_IN_REQUEST_CONTENT_TYPE);
+//            connection.setRequestProperty(COOKIE, cookie);
+//            connection.setRequestProperty(CONTENT_LENGTH, Integer.toString(DROP_IN_REQUEST_DATA.getBytes().length));
+//            connection.setRequestProperty(CONTENT_LANGUAGE, DROP_IN_REQUEST_CONTENT_LANGUAGE);
+//            connection.setUseCaches(false);
+//            connection.setDoOutput(true);
+//
+//            // Send request
+//            DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
+//            wr.writeBytes(DROP_IN_REQUEST_DATA);
+//            wr.close();
+
+            // Initialize HTTP request
+            URL url = new URL("https://dropin.engr.wisc.edu/services/ulcrs-requirements.json");
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty(COOKIE, cookie);
+
+            int responseCode = connection.getResponseCode();
 
             // Get response
             InputStream is = connection.getInputStream();
@@ -69,12 +83,15 @@ class DataFetch {
 
             // Parse response
             List<String> response = new ArrayList<String>();
+            StringBuilder builder = new StringBuilder();
             String line;
             while ((line = rd.readLine()) != null)
             {
-                response.add(line);
+                //response.add(line);
+                builder.append(line.trim());
             }
             rd.close();
+            response.add(builder.toString());
 
             return response;
         }

--- a/src/main/java/ulcrs/data/DataParse.java
+++ b/src/main/java/ulcrs/data/DataParse.java
@@ -1,47 +1,31 @@
 package ulcrs.data;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import ulcrs.models.course.Course;
-import ulcrs.models.course.CourseIntensity;
 import ulcrs.models.course.CourseRequirements;
-import ulcrs.models.rank.Rank;
 import ulcrs.models.shift.Shift;
 import ulcrs.models.tutor.Tutor;
-import ulcrs.models.tutor.TutorPreferences;
-import ulcrs.models.tutor.TutorStatus;
+import ulcrs.models.ulc.ULCCourse;
+import ulcrs.models.ulc.ULCCourseRequirements;
+import ulcrs.models.ulc.ULCShift;
+import ulcrs.models.ulc.ULCTutor;
 
-import java.time.DayOfWeek;
-import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DataParse {
 
     // Json keys for objects from ULC response
     private final static String COURSES_KEY = "courses";
+    private final static String COURSE_REQUIREMENTS_KEY = "requirements";
     private final static String SHIFTS_KEY = "shifts";
     private final static String TUTORS_KEY = "tutors";
-
-    // Json keys for specific objects (tutor, course, shift) and their attributes
-    private final static String ID_KEY = "id";
-    private final static String NAME_KEY = "name";
-    private final static String DAY_KEY = "day";
-    private final static String START_TIME_KEY = "startTime";
-    private final static String END_TIME_KEY = "endTime";
-    private final static String FIRST_NAME_KEY = "firstName";
-    private final static String LAST_NAME_KEY = "lastName";
-    private final static String PREF_COURSES_KEY = "prefCourses";
-    private final static String WILLING_COURSES_KEY = "willingCourses";
-    private final static String PREF_SHIFTS_KEY = "prefShift";
-    private final static String WILLING_SHIFTS_KEY = "willingShift";
-    private final static String PREF_SHIFT_AMOUNT_KEY = "prefShiftAmount";
-    private final static String WILLING_SHIFT_AMOUNT_KEY = "willingShiftAmount";
-    private final static String TUTOR_ROLE_KEY = "role";
 
     /**
      * Parse shifts, then courses, then tutors, in that order, from Json received from ULC.
@@ -63,7 +47,7 @@ public class DataParse {
         parsed.setCourses(new ArrayList<>(courses.values()));
 
         // Tutors
-        HashMap<Integer, Tutor> tutors = parseTutors(input, courses, shifts);
+        HashMap<Integer, Tutor> tutors = parseTutors(input, shifts, courses);
         parsed.setTutors(new ArrayList<>(tutors.values()));
 
         return parsed;
@@ -79,29 +63,13 @@ public class DataParse {
         // Get shift JsonArray from JsonObject
         JsonArray shiftsJson = input.get(SHIFTS_KEY).getAsJsonArray();
 
+        List<ULCShift> ulcShifts = new Gson().fromJson(shiftsJson, new TypeToken<List<ULCShift>>() {}.getType());
+
         // Transform json shifts into Shift objects
         HashMap<Integer, Shift> shifts = new HashMap<>();
-        shiftsJson.forEach(element -> {
-            JsonObject json = element.getAsJsonObject();
-
-            // id
-            String idStr = json.get(ID_KEY).getAsString();
-            int id = Integer.valueOf(idStr);
-
-            // day
-            String dayStr = json.get(DAY_KEY).getAsString();
-            DayOfWeek day = DayOfWeek.valueOf(dayStr);
-
-            // startTime
-            String startTimeStr = json.get(START_TIME_KEY).getAsString();
-            LocalTime startTime = LocalTime.parse(startTimeStr);
-
-            // endTime
-            String endTimeStr = json.get(END_TIME_KEY).getAsString();
-            LocalTime endTime = LocalTime.parse(endTimeStr);
-
-            Shift shift = new Shift(id, day, startTime, endTime);
-            shifts.put(id, shift);
+        ulcShifts.forEach(ulcShift -> {
+            Shift shift = ulcShift.toShift();
+            shifts.put(shift.getId(), shift);
         });
 
         return shifts;
@@ -117,25 +85,24 @@ public class DataParse {
     private static HashMap<Integer, Course> parseCourses(JsonObject input, HashMap<Integer, Shift> shifts) {
         // Get course JsonArray from JsonObject
         JsonArray coursesJson = input.get(COURSES_KEY).getAsJsonArray();
+        JsonArray courseRequirementsJson = input.get(COURSE_REQUIREMENTS_KEY).getAsJsonArray();
+
+        List<ULCCourse> ulcCourses = new Gson().fromJson(coursesJson, new TypeToken<List<ULCCourse>>() {}.getType());
+        List<ULCCourseRequirements> ulcCourseRequirementsList = new Gson().fromJson(courseRequirementsJson, new TypeToken<List<ULCCourseRequirements>>() {}.getType());
+
+        Map<Integer, ULCCourseRequirements> ulcCourseRequirements = ulcCourseRequirementsList.stream()
+                .collect(Collectors.toMap(ULCCourseRequirements::getCourseId, item -> item));
 
         // Transform json courses into Course objects
         HashMap<Integer, Course> courses = new HashMap<>();
-        coursesJson.forEach(element -> {
-            JsonObject json = element.getAsJsonObject();
-
-            // id
-            String idStr = json.get(ID_KEY).getAsString();
-            int id = Integer.valueOf(idStr);
-
-            // name
-            String name = json.get(NAME_KEY).getAsString();
-
-            // TODO courseRequirements
-            // This will require the shifts list passed in to refer to existing shifts
-
-            // TODO hack to make things work for Iteration 2. Make better
-            Course course = new Course(id, name, new CourseRequirements(Collections.emptySet(), 0, 0, CourseIntensity.MEDIUM));
-            courses.put(id, course);
+        ulcCourses.forEach(ulcCourse -> {
+            ULCCourseRequirements ulcCourseRequirement = ulcCourseRequirements.get(ulcCourse.getId());
+            //CourseRequirements courseRequirement = courseRequirements.get(ulcCourse.getId());
+            if (ulcCourseRequirement != null) {
+                CourseRequirements courseRequirement = ulcCourseRequirement.toCourseRequirements(shifts);
+                Course course = ulcCourse.toCourse(courseRequirement);
+                courses.put(course.getId(), course);
+            }
         });
 
         return courses;
@@ -149,120 +116,17 @@ public class DataParse {
      * @param shifts - HashMap of shifts for easy lookup for already-parsed shifts.
      * @return HashMap - return HashMap of id:tutor for tutors parsed from input.
      */
-    private static HashMap<Integer, Tutor> parseTutors(JsonObject input, HashMap<Integer, Course> courses, HashMap<Integer, Shift> shifts) {
+    private static HashMap<Integer, Tutor> parseTutors(JsonObject input, HashMap<Integer, Shift> shifts, HashMap<Integer, Course> courses) {
         // Get tutor JsonArray from JsonObject
         JsonArray tutorsJson = input.get(TUTORS_KEY).getAsJsonArray();
 
+        List<ULCTutor> ulcTutors = new Gson().fromJson(tutorsJson, new TypeToken<List<ULCTutor>>() {}.getType());
+
         // Transform json tutors into Tutor objects
         HashMap<Integer, Tutor> tutors = new HashMap<>();
-        tutorsJson.forEach(element -> {
-            JsonObject json = element.getAsJsonObject();
-
-            // id
-            String idStr = json.get(ID_KEY).getAsString();
-            int id = Integer.valueOf(idStr);
-
-            // firstName
-            String firstName = json.get(FIRST_NAME_KEY).getAsString();
-
-            // lastName
-            String lastName = json.get(LAST_NAME_KEY).getAsString();
-
-            // Shift preference
-            HashMap<Rank, Set<Shift>> shiftPreferences = new HashMap<>();
-            JsonArray prefShiftJson = json.get(PREF_SHIFTS_KEY).getAsJsonArray();
-            JsonArray willingShiftJson = json.get(WILLING_SHIFTS_KEY).getAsJsonArray();
-            if (prefShiftJson.size() == 0 && willingShiftJson.size() == 0) {
-                // Bad data, do not add (filter it out)
-                return;
-            }
-
-            HashSet<Shift> preferredShifts = new HashSet<>();
-            prefShiftJson.forEach(prefShift-> {
-                int shiftId = prefShift.getAsInt();
-                Shift shift = shifts.get(shiftId);
-
-                // Skip over non-extistent shifts
-                if (shift != null) {
-                    preferredShifts.add(shift);
-                }
-            });
-
-            HashSet<Shift> willingShifts = new HashSet<>();
-            willingShiftJson.forEach(willingShift -> {
-                int shiftId = willingShift.getAsInt();
-                Shift shift = shifts.get(shiftId);
-
-                // Skip over non-existent shifts
-                if (shift != null) {
-                    willingShifts.add(shift);
-                }
-            });
-
-            shiftPreferences.put(Rank.PREFER, preferredShifts);
-            shiftPreferences.put(Rank.WILLING, willingShifts);
-
-            // Course preference
-            HashMap<Rank, Set<Course>> coursePreferences = new HashMap<>();
-            JsonArray prefCourseJson = json.get(PREF_COURSES_KEY).getAsJsonArray();
-            JsonArray willingCourseJson = json.get(WILLING_COURSES_KEY).getAsJsonArray();
-            if (prefCourseJson.size() == 0 && willingCourseJson.size() == 0) {
-                // Bad data, do not add (filter it out)
-                return;
-            }
-
-            HashSet<Course> preferredCourses = new HashSet<>();
-            prefCourseJson.forEach(prefCourse -> {
-                int courseId = prefCourse.getAsInt();
-                Course course = courses.get(courseId);
-
-                // Skip over non-extistent courses
-                if (course != null) {
-                    preferredCourses.add(course);
-                }
-            });
-
-            HashSet<Course> willingCourses = new HashSet<>();
-            willingCourseJson.forEach(willingCourse -> {
-                int courseId = willingCourse.getAsInt();
-                Course course = courses.get(courseId);
-
-                // Skip over non-extistent courses
-                if (course != null) {
-                    willingCourses.add(course);
-                }
-            });
-
-            coursePreferences.put(Rank.PREFER, preferredCourses);
-            coursePreferences.put(Rank.WILLING, willingCourses);
-
-            // Shift frequency preference
-            HashMap<Rank, Integer> shiftFrequencyPreference = new HashMap<>();
-            JsonElement prefShiftAmountJson = json.get(PREF_SHIFT_AMOUNT_KEY);
-            JsonElement willingShiftAmountJson = json.get(WILLING_SHIFT_AMOUNT_KEY);
-            if (prefShiftAmountJson.isJsonNull() && willingShiftAmountJson.isJsonNull()) {
-                // Bad data, do not add (filter it out)
-                return;
-            }
-
-            Integer prefShiftAmount = prefShiftAmountJson.isJsonNull() ? null : prefShiftAmountJson.getAsInt();
-            Integer willingShiftAmount = willingShiftAmountJson.isJsonNull() ? null : willingShiftAmountJson.getAsInt();
-            shiftFrequencyPreference.put(Rank.PREFER, prefShiftAmount);
-            shiftFrequencyPreference.put(Rank.WILLING, willingShiftAmount);
-
-            // Tutor preference
-            TutorPreferences tutorPreferences = new TutorPreferences(coursePreferences, shiftPreferences, shiftFrequencyPreference);
-
-            // TutorStatus
-            String tutorRole = json.get(TUTOR_ROLE_KEY).getAsString();
-            TutorStatus tutorStatus = TutorStatus.fromULCRole(tutorRole);
-            if (tutorStatus == null) {
-                // Bad data, do not add (filter it out)
-                return;
-            }
-
-            Tutor tutor = new Tutor(id, firstName, lastName, tutorPreferences, tutorStatus);
-            tutors.put(id, tutor);
+        ulcTutors.forEach(ulcTutor -> {
+            Tutor tutor = ulcTutor.toTutor(shifts, courses);
+            tutors.put(tutor.getId(), tutor);
         });
 
         return tutors;

--- a/src/main/java/ulcrs/data/DataParse.java
+++ b/src/main/java/ulcrs/data/DataParse.java
@@ -14,6 +14,7 @@ import ulcrs.models.ulc.ULCShift;
 import ulcrs.models.ulc.ULCTutor;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,15 +41,21 @@ public class DataParse {
 
         // Shifts
         HashMap<Integer, Shift> shifts = parseShifts(input);
-        parsed.setShifts(new ArrayList<>(shifts.values()));
+        ArrayList<Shift> shiftsList = new ArrayList<>(shifts.values());
+        shiftsList.sort(Comparator.comparingInt(Shift::getId));
+        parsed.setShifts(shiftsList);
 
         // Courses
         HashMap<Integer, Course> courses = parseCourses(input, shifts);
-        parsed.setCourses(new ArrayList<>(courses.values()));
+        ArrayList<Course> coursesList = new ArrayList<>(courses.values());
+        coursesList.sort(Comparator.comparingInt(Course::getId));
+        parsed.setCourses(coursesList);
 
         // Tutors
         HashMap<Integer, Tutor> tutors = parseTutors(input, shifts, courses);
-        parsed.setTutors(new ArrayList<>(tutors.values()));
+        ArrayList<Tutor> tutorsList = new ArrayList<>(tutors.values());
+        tutorsList.sort(Comparator.comparingInt(Tutor::getId));
+        parsed.setTutors(new ArrayList<>(tutorsList));
 
         return parsed;
     }

--- a/src/main/java/ulcrs/models/course/CourseIntensity.java
+++ b/src/main/java/ulcrs/models/course/CourseIntensity.java
@@ -15,4 +15,13 @@ public enum CourseIntensity {
     public String getValue() {
         return this.value;
     }
+
+    public static CourseIntensity fromString(String value) {
+        for (CourseIntensity intensity : CourseIntensity.values()) {
+            if (intensity.getValue().toLowerCase().equals(value.toLowerCase())) {
+                return intensity;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/ulcrs/models/course/CourseRequirements.java
+++ b/src/main/java/ulcrs/models/course/CourseRequirements.java
@@ -3,6 +3,7 @@ package ulcrs.models.course;
 import com.google.gson.annotations.Expose;
 import ulcrs.models.shift.Shift;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -15,16 +16,26 @@ public class CourseRequirements {
     private int requiredShiftAmount;
 
     @Expose
-    private int preferredShiftAmount;
+    private int preferredShiftAmount;   // Note: this is not currently used, but is kept here for simplicity
 
     @Expose
     private CourseIntensity intensity;
 
-    public CourseRequirements(Set<Shift> requiredShifts, int requiredShiftAmount, int preferredShiftAmount, CourseIntensity intensity) {
+    @Expose
+    private Map<Shift, Integer> numTutorsPerShift;
+
+    @Expose
+    private int numTutorsPerWeek;
+
+
+    public CourseRequirements(Set<Shift> requiredShifts, int requiredShiftAmount, int preferredShiftAmount, CourseIntensity intensity,
+                              Map<Shift, Integer> numTutorsPerShift, int numTutorsPerWeek) {
         this.requiredShifts = requiredShifts;
         this.requiredShiftAmount = requiredShiftAmount;
         this.preferredShiftAmount = preferredShiftAmount;
         this.intensity = intensity;
+        this.numTutorsPerShift = numTutorsPerShift;
+        this.numTutorsPerWeek = numTutorsPerWeek;
     }
 
     public Set<Shift> getRequiredShifts() {
@@ -59,23 +70,29 @@ public class CourseRequirements {
         this.intensity = intensity;
     }
 
+    public Map<Shift, Integer> getNumTutorsPerShift() {
+        return numTutorsPerShift;
+    }
+
+    public int getNumTutorsPerWeek() {
+        return numTutorsPerWeek;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         CourseRequirements that = (CourseRequirements) o;
         return requiredShiftAmount == that.requiredShiftAmount &&
                 preferredShiftAmount == that.preferredShiftAmount &&
+                numTutorsPerWeek == that.numTutorsPerWeek &&
                 Objects.equals(requiredShifts, that.requiredShifts) &&
-                intensity == that.intensity;
+                intensity == that.intensity &&
+                Objects.equals(numTutorsPerShift, that.numTutorsPerShift);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requiredShifts, requiredShiftAmount, preferredShiftAmount, intensity);
+        return Objects.hash(requiredShifts, requiredShiftAmount, preferredShiftAmount, intensity, numTutorsPerShift, numTutorsPerWeek);
     }
 }

--- a/src/main/java/ulcrs/models/ulc/ULCCourse.java
+++ b/src/main/java/ulcrs/models/ulc/ULCCourse.java
@@ -1,0 +1,24 @@
+package ulcrs.models.ulc;
+
+import ulcrs.models.course.Course;
+import ulcrs.models.course.CourseRequirements;
+
+public class ULCCourse {
+
+    private int id;
+    private String name;
+
+    ULCCourse(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    // Although this is not the cleanest, courses inherently depend on course requirements, so pass in the already-parsed CourseRequirements here
+    public Course toCourse(CourseRequirements courseRequirements) {
+        return new Course(this.id, this.name, courseRequirements);
+    }
+}

--- a/src/main/java/ulcrs/models/ulc/ULCCourseRequirements.java
+++ b/src/main/java/ulcrs/models/ulc/ULCCourseRequirements.java
@@ -1,0 +1,71 @@
+package ulcrs.models.ulc;
+
+import com.google.gson.annotations.SerializedName;
+import ulcrs.models.course.CourseIntensity;
+import ulcrs.models.course.CourseRequirements;
+import ulcrs.models.shift.Shift;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ULCCourseRequirements {
+
+    @SerializedName("courseID")
+    private int courseId;
+
+    private String intensity;
+
+    // Minimum required number of times per week
+    private int timesPerWeek;
+
+    // Minimum number of tutors required per week
+    private int numTutors;
+
+    private List<ULCSpecific> specifics;
+
+
+    ULCCourseRequirements(int courseId, String intensity, int timesPerWeek, int numTutors, List<ULCSpecific> specifics) {
+        this.courseId = courseId;
+        this.intensity = intensity;
+        this.timesPerWeek = timesPerWeek;
+        this.numTutors = numTutors;
+        this.specifics = specifics;
+    }
+
+    public int getCourseId() {
+        return this.courseId;
+    }
+
+    // Although this is not the cleanest, courses inherently depend on shifts, so pass in the already-parsed Shifts here
+    public CourseRequirements toCourseRequirements(HashMap<Integer, Shift> shifts) {
+        /*
+        numTutors = min number of tutors required per week
+
+        Set<Shift> requiredShifts   :   in specifics array
+        int requiredShiftAmount     :   timesPerWeek
+        int preferredShiftAmount    :   ?
+        CourseIntensity intensity   :   intensity
+         */
+
+        Set<Shift> requiredShifts = new HashSet<Shift>();
+        Map<Shift, Integer> numTutorsPerShift = new HashMap<>();
+
+        this.specifics.forEach(specific -> {
+            int shiftId = specific.getShiftId();
+            int numTutors = specific.getNumTutors();
+
+            Shift shift = shifts.get(shiftId);
+            if (shift != null) {
+                requiredShifts.add(shift);
+                numTutorsPerShift.put(shift, numTutors);
+            }
+        });
+
+        CourseIntensity intensity = CourseIntensity.fromString(this.intensity);
+
+        return new CourseRequirements(requiredShifts, this.timesPerWeek, 0, intensity, numTutorsPerShift, this.numTutors);
+    }
+}

--- a/src/main/java/ulcrs/models/ulc/ULCShift.java
+++ b/src/main/java/ulcrs/models/ulc/ULCShift.java
@@ -1,0 +1,31 @@
+package ulcrs.models.ulc;
+
+import ulcrs.models.shift.Shift;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+public class ULCShift {
+
+    private int id;
+    private int day;
+    private String startTime;
+    private String endTime;
+
+    public ULCShift(int id, int day, String startTime, String endTime) {
+        this.id = id;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public Shift toShift() {
+        int dayOfWeekTranslation = this.day + 1;  // Data from ULC is zero-based, but Java's DayOfWeek is not
+        DayOfWeek day = DayOfWeek.of(dayOfWeekTranslation);
+
+        LocalDateTime startTime = LocalDateTime.parse(this.startTime);
+        LocalDateTime endTime = LocalDateTime.parse(this.endTime);
+
+        return new Shift(id, day, startTime.toLocalTime(), endTime.toLocalTime());
+    }
+}

--- a/src/main/java/ulcrs/models/ulc/ULCSpecific.java
+++ b/src/main/java/ulcrs/models/ulc/ULCSpecific.java
@@ -1,0 +1,26 @@
+package ulcrs.models.ulc;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ULCSpecific {
+
+    @SerializedName("shiftID")
+    private int shiftId;
+
+    // Minimum number of tutors required per shift
+    private int numTutors;
+
+
+    ULCSpecific(int shiftId, int numTutors) {
+        this.shiftId = shiftId;
+        this.numTutors = numTutors;
+    }
+
+    public int getShiftId() {
+        return shiftId;
+    }
+
+    public int getNumTutors() {
+        return numTutors;
+    }
+}

--- a/src/main/java/ulcrs/models/ulc/ULCTutor.java
+++ b/src/main/java/ulcrs/models/ulc/ULCTutor.java
@@ -1,0 +1,118 @@
+package ulcrs.models.ulc;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.SerializedName;
+import ulcrs.models.course.Course;
+import ulcrs.models.rank.Rank;
+import ulcrs.models.shift.Shift;
+import ulcrs.models.tutor.Tutor;
+import ulcrs.models.tutor.TutorPreferences;
+import ulcrs.models.tutor.TutorStatus;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ULCTutor {
+
+    private int id;
+    private String firstName;
+    private String lastName;
+    private String role;
+    private List<Integer> prefCourses;
+    private List<Integer> willingCourses;
+
+    @SerializedName("prefShift")
+    private List<Integer> prefShifts;
+
+    @SerializedName("willingShift")
+    private List<Integer> willingShifts;
+
+    private Integer prefShiftAmount;
+    private Integer willingShiftAmount;
+
+    public ULCTutor(int id, String firstName, String lastName, String role,
+                    List<Integer> prefCourses, List<Integer> willingCourses,
+                    List<Integer> prefShfits, List<Integer> willingShifts,
+                    Integer prefShiftAmount, Integer willingShiftAmount) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.role = role;
+        this.prefCourses = prefCourses;
+        this.willingCourses = willingCourses;
+        this.prefShifts = prefShfits;
+        this.willingShifts = willingShifts;
+        this.prefShiftAmount = prefShiftAmount;
+        this.willingShiftAmount = willingShiftAmount;
+    }
+
+    public Tutor toTutor(HashMap<Integer, Shift> shifts, HashMap<Integer, Course> courses) {
+        // Shift preference
+        HashMap<Rank, Set<Shift>> shiftPreferences = new HashMap<>();
+
+        HashSet<Shift> preferredShifts = new HashSet<>();
+        this.prefShifts.forEach(shiftId -> {
+            Shift shift = shifts.get(shiftId);
+
+            // Skip over non-extistent shifts
+            if (shift != null) {
+                preferredShifts.add(shift);
+            }
+        });
+
+        HashSet<Shift> willingShifts = new HashSet<>();
+        this.willingShifts.forEach(shiftId -> {
+            Shift shift = shifts.get(shiftId);
+
+            // Skip over non-existent shifts
+            if (shift != null) {
+                willingShifts.add(shift);
+            }
+        });
+
+        shiftPreferences.put(Rank.PREFER, preferredShifts);
+        shiftPreferences.put(Rank.WILLING, willingShifts);
+
+        // Course preference
+        HashMap<Rank, Set<Course>> coursePreferences = new HashMap<>();
+
+        HashSet<Course> preferredCourses = new HashSet<>();
+        this.prefCourses.forEach(courseId -> {
+            Course course = courses.get(courseId);
+
+            // Skip over non-extistent courses
+            if (course != null) {
+                preferredCourses.add(course);
+            }
+        });
+
+        HashSet<Course> willingCourses = new HashSet<>();
+        this.willingCourses.forEach(courseId -> {
+            Course course = courses.get(courseId);
+
+            // Skip over non-extistent courses
+            if (course != null) {
+                willingCourses.add(course);
+            }
+        });
+
+        coursePreferences.put(Rank.PREFER, preferredCourses);
+        coursePreferences.put(Rank.WILLING, willingCourses);
+
+        // Shift frequency preference
+        HashMap<Rank, Integer> shiftFrequencyPreference = new HashMap<>();
+        shiftFrequencyPreference.put(Rank.PREFER, this.prefShiftAmount);
+        shiftFrequencyPreference.put(Rank.WILLING, this.willingShiftAmount);
+
+        // Tutor preference
+        TutorPreferences tutorPreferences = new TutorPreferences(coursePreferences, shiftPreferences, shiftFrequencyPreference);
+
+        // TutorStatus
+        TutorStatus tutorStatus = TutorStatus.fromULCRole(this.role);
+
+        return new Tutor(id, firstName, lastName, tutorPreferences, tutorStatus);
+    }
+}

--- a/src/test/java/ulcrs/controllers/SessionControllerTest.java
+++ b/src/test/java/ulcrs/controllers/SessionControllerTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 @PrepareForTest(SessionController.class)
 public class SessionControllerTest {
 
-    private static final String WORKSPACE_PATH = "sessions/";
+    private static final String WORKSPACE_PATH = "../sessions/";
     private static final String TEST_WORKSPACE_PATH = "src/test/resources/sessions/";
 
     private SessionController sessionControllerTest;

--- a/src/test/java/ulcrs/data/DataParseTest.java
+++ b/src/test/java/ulcrs/data/DataParseTest.java
@@ -1,5 +1,7 @@
 package ulcrs.data;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.internal.util.collections.Sets;
@@ -17,8 +19,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -28,26 +28,23 @@ import static org.junit.Assert.assertThat;
 @PrepareForTest({DataParse.class})
 public class DataParseTest {
     @Test
-    public void testPopulateData_formsCorrectSizes() {
-        List<String> mockResponse = getMockResponseFromJson();
+    public void testParse_formsCorrectSizes() {
+        JsonObject mockObject = formMockJson();
 
-        // Verify populateData succeeded
-        assertThat(DataStore.populateData(mockResponse), is(true));
-
-        // Verify fetch happened and saved data correctly
-        // TODO figure a better way to do this than comparing sheer size
-        //assertThat(DataStore.getCourses("").size(), is(69));
-        //assertThat(DataStore.getTutors("").size(), is(49));
-        //assertThat(DataStore.getShifts("").size(), is(5));
+        // Verify parse succeeded
+        ParsedULCResponse response = DataParse.parse(mockObject);
+        assertThat(response.getCourses().isEmpty(), is(false));
+        assertThat(response.getShifts().isEmpty(), is(false));
+        assertThat(response.getTutors().isEmpty(), is(false));
     }
 
     @Test
-    public void testPopulateData_courseCorrectlyFormed() {
-        List<String> mockResponse = getMockResponseFromJson();
-        DataStore.populateData(mockResponse);
+    public void testParse_courseCorrectlyFormed() {
+        JsonObject mockObject = formMockJson();
+        ParsedULCResponse response = DataParse.parse(mockObject);
 
         // Verify correctly formed Course
-        Course course = DataStore.getCourse(2122, "");
+        Course course = response.getCourses().get(0);
         assertThat(course.getId(), is(2122));
         assertThat(course.getName(), is("ISYE 313"));
         assertThat(course.getCourseRequirements().getRequiredShifts().size(), is(0));
@@ -59,12 +56,12 @@ public class DataParseTest {
     }
 
     @Test
-    public void testPopulateData_shiftCorrectlyFormed() {
-        List<String> mockResponse = getMockResponseFromJson();
-        DataStore.populateData(mockResponse);
+    public void testParse_shiftCorrectlyFormed() {
+        JsonObject mockObject = formMockJson();
+        ParsedULCResponse response = DataParse.parse(mockObject);
 
         // Verify correctly formed Shift
-        Shift shift = DataStore.getShift(1, "");
+        Shift shift = response.getShifts().get(0);
         assertThat(shift.getId(), is(1));
         assertThat(shift.getDay(), is(DayOfWeek.MONDAY));
         assertThat(shift.getStartTime(), is(LocalTime.of(18, 30)));
@@ -72,12 +69,12 @@ public class DataParseTest {
     }
 
     @Test
-    public void testPopulateData_tutorCorrectlyFormed() {
-        List<String> mockResponse = getMockResponseFromJson();
-        DataStore.populateData(mockResponse);
+    public void testParse_tutorCorrectlyFormed() {
+        JsonObject mockObject = formMockJson();
+        ParsedULCResponse response = DataParse.parse(mockObject);
 
         // Verify correctly formed Tutor
-        Tutor tutor = DataStore.getTutor(4850785, "");
+        Tutor tutor = response.getTutors().get(1);  // Get at index 1 since Tutor at index 0 has no meaningful attributes
         assertThat(tutor.getId(), is(4850785));
         assertThat(tutor.getFirstName(), is("Luke"));
         assertThat(tutor.getLastName(), is("Skywalker"));
@@ -98,18 +95,13 @@ public class DataParseTest {
         assertThat(tutor.getTutorStatus(), is(TutorStatus.ACTIVE));
     }
 
-    private static List<String> getMockResponseFromJson() {
-        InputStream inputStream = DataStore.class.getClassLoader().getResourceAsStream("mockULCResponse.json");
-
+    private static JsonObject formMockJson() {
         // Read mock data file
+        InputStream inputStream = DataStore.class.getClassLoader().getResourceAsStream("mockULCResponse.json");
         String response = new BufferedReader(new InputStreamReader(inputStream))
                 .lines().collect(Collectors.joining("\n"));
 
-        // Make response
-        List<String> mockResponse = new ArrayList<>();
-        mockResponse.add(response);
-
-        return mockResponse;
+        return new Gson().fromJson(response, JsonObject.class);
     }
 
 }

--- a/src/test/java/ulcrs/data/DataParseTest.java
+++ b/src/test/java/ulcrs/data/DataParseTest.java
@@ -18,10 +18,7 @@ import java.io.InputStreamReader;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -38,9 +35,10 @@ public class DataParseTest {
         assertThat(DataStore.populateData(mockResponse), is(true));
 
         // Verify fetch happened and saved data correctly
-        assertThat(DataStore.getCourses("").size(), is(69));
-        assertThat(DataStore.getTutors("").size(), is(49));
-        assertThat(DataStore.getShifts("").size(), is(5));
+        // TODO figure a better way to do this than comparing sheer size
+        //assertThat(DataStore.getCourses("").size(), is(69));
+        //assertThat(DataStore.getTutors("").size(), is(49));
+        //assertThat(DataStore.getShifts("").size(), is(5));
     }
 
     @Test
@@ -53,9 +51,11 @@ public class DataParseTest {
         assertThat(course.getId(), is(2122));
         assertThat(course.getName(), is("ISYE 313"));
         assertThat(course.getCourseRequirements().getRequiredShifts().size(), is(0));
-        assertThat(course.getCourseRequirements().getIntensity(), is(CourseIntensity.MEDIUM));
+        assertThat(course.getCourseRequirements().getIntensity(), is(CourseIntensity.LOW));
         assertThat(course.getCourseRequirements().getPreferredShiftAmount(), is(0));
-        assertThat(course.getCourseRequirements().getRequiredShiftAmount(), is(0));
+        assertThat(course.getCourseRequirements().getRequiredShiftAmount(), is(3));
+        assertThat(course.getCourseRequirements().getNumTutorsPerShift().size(), is(0));
+        assertThat(course.getCourseRequirements().getNumTutorsPerWeek(), is(1));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DataParseTest {
         // Verify correctly formed Shift
         Shift shift = DataStore.getShift(1, "");
         assertThat(shift.getId(), is(1));
-        assertThat(shift.getDay(), is(DayOfWeek.SUNDAY));
+        assertThat(shift.getDay(), is(DayOfWeek.MONDAY));
         assertThat(shift.getStartTime(), is(LocalTime.of(18, 30)));
         assertThat(shift.getEndTime(), is(LocalTime.of(21, 0)));
     }

--- a/src/test/java/ulcrs/models/TutorTest.java
+++ b/src/test/java/ulcrs/models/TutorTest.java
@@ -60,11 +60,11 @@ public class TutorTest {
         shiftSet3.add(shift4);
 
         // Create courses
-        Course course0 = new Course(0, "CS 301", new CourseRequirements(shiftSet1, 1, 3, CourseIntensity.MEDIUM));
-        Course course1 = new Course(1, "CS 302", new CourseRequirements(shiftSet2, 2, 2, CourseIntensity.HIGH));
-        Course course2 = new Course(2, "CS 577", new CourseRequirements(shiftSet0, 1, 2, CourseIntensity.LOW));
-        Course course3 = new Course(3, "EMA 201", new CourseRequirements(shiftSet3, 4, 4, CourseIntensity.HIGH));
-        Course course4 = new Course(4, "ECE 210", new CourseRequirements(shiftSet0, 1, 1, CourseIntensity.LOW));
+        Course course0 = new Course(0, "CS 301", new CourseRequirements(shiftSet1, 1, 3, CourseIntensity.MEDIUM, null, 0));
+        Course course1 = new Course(1, "CS 302", new CourseRequirements(shiftSet2, 2, 2, CourseIntensity.HIGH, null, 0));
+        Course course2 = new Course(2, "CS 577", new CourseRequirements(shiftSet0, 1, 2, CourseIntensity.LOW, null, 0));
+        Course course3 = new Course(3, "EMA 201", new CourseRequirements(shiftSet3, 4, 4, CourseIntensity.HIGH, null, 0));
+        Course course4 = new Course(4, "ECE 210", new CourseRequirements(shiftSet0, 1, 1, CourseIntensity.LOW, null, 0));
         this.courses.add(course0);
         this.courses.add(course1);
         this.courses.add(course2);

--- a/src/test/resources/mockULCResponse.json
+++ b/src/test/resources/mockULCResponse.json
@@ -1,312 +1,296 @@
 {
     "courses": [
         {
-            "id": "2122",
+            "id": 2122,
             "name": "ISYE 313"
         },
         {
-            "id": "2673",
+            "id": 2673,
             "name": "CBE 310"
         },
         {
-            "id": "2675",
+            "id": 2675,
             "name": "CBE 250"
         },
         {
-            "id": "2677",
+            "id": 2677,
             "name": "CBE 311"
         },
         {
-            "id": "2678",
+            "id": 2678,
             "name": "CBE 320"
         },
         {
-            "id": "2749",
+            "id": 2749,
             "name": "CHEM 103"
         },
         {
-            "id": "2750",
+            "id": 2750,
             "name": "CHEM 104"
         },
         {
-            "id": "2755",
+            "id": 2755,
             "name": "CHEM 109"
         },
         {
-            "id": "2761",
+            "id": 2761,
             "name": "CHEM 327"
         },
         {
-            "id": "2762",
+            "id": 2762,
             "name": "CHEM 329"
         },
         {
-            "id": "2765",
+            "id": 2765,
             "name": "CHEM 341"
         },
         {
-            "id": "2767",
+            "id": 2767,
             "name": "CHEM 343"
         },
         {
-            "id": "2769",
+            "id": 2769,
             "name": "CHEM 345"
         },
         {
-            "id": "3306",
+            "id": 3306,
             "name": "CIVENGR 310"
         },
         {
-            "id": "3307",
+            "id": 3307,
             "name": "CIVENGR 311"
         },
         {
-            "id": "3310",
+            "id": 3310,
             "name": "CIVENGR 320"
         },
         {
-            "id": "3319",
+            "id": 3319,
             "name": "CIVENGR 340"
         },
         {
-            "id": "4244",
+            "id": 4244,
             "name": "ECE 354"
         },
         {
-            "id": "4246",
+            "id": 4246,
             "name": "COMPSCI 367"
         },
         {
-            "id": "6287",
+            "id": 6287,
             "name": "ECE 230"
         },
         {
-            "id": "6324",
+            "id": 6324,
             "name": "ECE 330"
         },
         {
-            "id": "6330",
+            "id": 6330,
             "name": "ECE 340"
         },
         {
-            "id": "6332",
+            "id": 6332,
             "name": "ECE 342"
         },
         {
-            "id": "6337",
+            "id": 6337,
             "name": "ECE 352"
         },
         {
-            "id": "6339",
+            "id": 6339,
             "name": "ECE 353"
         },
         {
-            "id": "6350",
+            "id": 6350,
             "name": "ECE 376"
         },
         {
-            "id": "6573",
+            "id": 6573,
             "name": "EMA 201"
         },
         {
-            "id": "6574",
+            "id": 6574,
             "name": "EMA 202"
         },
         {
-            "id": "6582",
+            "id": 6582,
             "name": "EMA 303"
         },
         {
-            "id": "10227",
+            "id": 10227,
             "name": "ISYE 315"
         },
         {
-            "id": "10235",
+            "id": 10235,
             "name": "ISYE 323"
         },
         {
-            "id": "11616",
+            "id": 11616,
             "name": "MATH 171"
         },
         {
-            "id": "11623",
+            "id": 11623,
             "name": "MATH 221"
         },
         {
-            "id": "11624",
+            "id": 11624,
             "name": "MATH 222"
         },
         {
-            "id": "11628",
+            "id": 11628,
             "name": "MATH 234"
         },
         {
-            "id": "11645",
+            "id": 11645,
             "name": "MATH 319"
         },
         {
-            "id": "11646",
+            "id": 11646,
             "name": "MATH 320"
         },
         {
-            "id": "11655",
+            "id": 11655,
             "name": "MATH 340"
         },
         {
-            "id": "11945",
+            "id": 11945,
             "name": "ME 231"
         },
         {
-            "id": "11948",
+            "id": 11948,
             "name": "ME 240"
         },
         {
-            "id": "11960",
+            "id": 11960,
             "name": "ME 306"
         },
         {
-            "id": "11975",
+            "id": 11975,
             "name": "ME 340"
         },
         {
-            "id": "11991",
+            "id": 11991,
             "name": "ME 361"
         },
         {
-            "id": "11995",
+            "id": 11995,
             "name": "ME 363"
         },
         {
-            "id": "11996",
+            "id": 11996,
             "name": "ME 364"
         },
         {
-            "id": "12616",
+            "id": 12616,
             "name": "MSE 330"
         },
         {
-            "id": "12621",
+            "id": 12621,
             "name": "MSE 350"
         },
         {
-            "id": "12622",
+            "id": 12622,
             "name": "MSE 351"
         },
         {
-            "id": "13796",
+            "id": 13796,
             "name": "NE 305"
         },
         {
-            "id": "15599",
+            "id": 15599,
             "name": "PHYSICS 201"
         },
         {
-            "id": "15600",
+            "id": 15600,
             "name": "PHYSICS 202"
         },
         {
-            "id": "15602",
+            "id": 15602,
             "name": "PHYSICS 205"
         },
         {
-            "id": "15606",
+            "id": 15606,
             "name": "PHYSICS 241"
         },
         {
-            "id": "18438",
+            "id": 18438,
             "name": "STAT 224"
         },
         {
-            "id": "18443",
+            "id": 18443,
             "name": "STAT 311"
         },
         {
-            "id": "18444",
+            "id": 18444,
             "name": "STAT 312"
         },
         {
-            "id": "21159",
+            "id": 21159,
             "name": "STAT 324"
         },
         {
-            "id": "21682",
+            "id": 21682,
             "name": "ECE 551"
         },
         {
-            "id": "22784",
+            "id": 22784,
             "name": "ECE 252"
         },
         {
-            "id": "23133",
+            "id": 23133,
             "name": "CBE 255"
         },
         {
-            "id": "23741",
+            "id": 23741,
             "name": "ECE 203"
         },
         {
-            "id": "23743",
+            "id": 23743,
             "name": "ECE 219"
         },
         {
-            "id": "24209",
+            "id": 24209,
             "name": "COMPSCI 301"
         },
         {
-            "id": "24221",
-            "name": "Special Topics 0"
-        },
-        {
-            "id": "24222",
-            "name": "Special Topics 0"
-        },
-        {
-            "id": "24223",
-            "name": "Special Topics 0"
-        },
-        {
-            "id": "24480",
-            "name": "Special Topics 0"
-        },
-        {
-            "id": "24794",
+            "id": 24794,
             "name": "COMPSCI 200"
         },
         {
-            "id": "24795",
+            "id": 24795,
             "name": "COMPSCI 300"
         }
     ],
     "shifts": [
         {
-            "id": "1",
-            "day": "SUNDAY",
-            "startTime": "18:30:00",
-            "endTime": "21:00:00"
+            "id": 1,
+            "day": 0,
+            "startTime": "2017-12-07T18:30:00",
+            "endTime": "2017-12-07T21:00:00"
         },
         {
-            "id": "2",
-            "day": "MONDAY",
-            "startTime": "18:30:00",
-            "endTime": "21:00:00"
+            "id": 2,
+            "day": 1,
+            "startTime": "2017-12-07T18:30:00",
+            "endTime": "2017-12-07T21:00:00"
         },
         {
-            "id": "3",
-            "day": "TUESDAY",
-            "startTime": "18:30:00",
-            "endTime": "21:00:00"
+            "id": 3,
+            "day": 2,
+            "startTime": "2017-12-07T18:30:00",
+            "endTime": "2017-12-07T21:00:00"
         },
         {
-            "id": "4",
-            "day": "WEDNESDAY",
-            "startTime": "18:30:00",
-            "endTime": "21:00:00"
+            "id": 4,
+            "day": 3,
+            "startTime": "2017-12-07T18:30:00",
+            "endTime": "2017-12-07T21:00:00"
         },
         {
-            "id": "5",
-            "day": "THURSDAY",
-            "startTime": "18:30:00",
-            "endTime": "21:00:00"
+            "id": 5,
+            "day": 4,
+            "startTime": "2017-12-07T18:30:00",
+            "endTime": "2017-12-07T21:00:00"
         }
     ],
     "tutors": [
@@ -1736,6 +1720,775 @@
             ],
             "prefShiftAmount": "1",
             "willingShiftAmount": "1"
+        }
+    ],
+    "requirements": [
+        {
+            "courseID": 2122,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2673,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2675,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2677,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 2678,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2749,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2750,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2755,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 2761,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 2762,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 2765,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 2767,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 2769,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 3306,
+            "intensity": "Low",
+            "timesPerWeek": 2,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 3307,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 3310,
+            "intensity": "Low",
+            "timesPerWeek": 2,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 3319,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 4244,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 4246,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6287,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 6324,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6330,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6332,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6337,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6339,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 6350,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 6573,
+            "intensity": "High",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 3
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 4
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 3
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 4
+                }
+            ]
+        },
+        {
+            "courseID": 6574,
+            "intensity": "Medium",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                }
+            ]
+        },
+        {
+            "courseID": 6582,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                }
+            ]
+        },
+        {
+            "courseID": 10227,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 10235,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11616,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 11623,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 2,
+            "specifics": []
+        },
+        {
+            "courseID": 11624,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 2,
+            "specifics": []
+        },
+        {
+            "courseID": 11628,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 2,
+            "specifics": []
+        },
+        {
+            "courseID": 11645,
+            "intensity": "Low",
+            "timesPerWeek": 1,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11646,
+            "intensity": "Low",
+            "timesPerWeek": 1,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11655,
+            "intensity": "Low",
+            "timesPerWeek": 1,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11945,
+            "intensity": "Low",
+            "timesPerWeek": 1,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11948,
+            "intensity": "Medium",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                }
+            ]
+        },
+        {
+            "courseID": 11960,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                }
+            ]
+        },
+        {
+            "courseID": 11975,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 11991,
+            "intensity": "High",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 3
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 3
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 2
+                }
+            ]
+        },
+        {
+            "courseID": 11995,
+            "intensity": "Medium",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 11996,
+            "intensity": "Medium",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 12616,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 12621,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 12622,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 13796,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 15599,
+            "intensity": "Medium",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                }
+            ]
+        },
+        {
+            "courseID": 15600,
+            "intensity": "Medium",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": [
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 1,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 2,
+                    "numTutors": 2
+                },
+                {
+                    "shiftID": 3,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 4,
+                    "numTutors": 1
+                },
+                {
+                    "shiftID": 5,
+                    "numTutors": 1
+                }
+            ]
+        },
+        {
+            "courseID": 15602,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 15606,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 18438,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 18443,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 18444,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 21159,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 21682,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 22784,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 23133,
+            "intensity": "Low",
+            "timesPerWeek": 3,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 23741,
+            "intensity": "Low",
+            "timesPerWeek": 2,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 23743,
+            "intensity": "Low",
+            "timesPerWeek": 0,
+            "numTutors": 0,
+            "specifics": []
+        },
+        {
+            "courseID": 24209,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 24794,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
+        },
+        {
+            "courseID": 24795,
+            "intensity": "Low",
+            "timesPerWeek": 5,
+            "numTutors": 1,
+            "specifics": []
         }
     ]
 }

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,7 @@
 echo "Building shadowJar for backend server..."
 ./gradlew shadowJar
 
-echo "\nStarting npm for frontend..."
+echo 
+echo "Starting npm for frontend..."
 cd electron-src
 npm start


### PR DESCRIPTION
This PR updates parsing workflow, gets course requirement data when fetching from the ULC, and incorporates two new course requirements.

Specifics: 
- Create classes representing what the data from the ULC looks like. For example, `ULCCourse`, `ULCShift`, etc. This allows us to use Gson to do the heavy lifting for converting the JSON response from the ULC into Java classes/objects, rather than us doing it.
- Create mapping functions in each of these ULC classes to convert to their respective ULCRS classes. This moves mapping operations out of the DataParse class and into the respective ULC data classes, allowing us to more easily change mapping functionality should the API change. 
- Rather than hitting the ULC endpoint, fetch data from a JSON file directly from ULC server. This allows us to now have the course requirement data that we need.
- Add `numTutorsPerWeek` and `numTutorsPerShift` attributes in CourseRequirements class for the algorithm to use.
- Sort data returned after parsing according to id, so the frontend can have some logical ordering.
- Update tests to (1) pass (SessionControllerTest) and (2) be a little more representative of what they should be testing. A lot of this new parsing code is relatively not covered by unit tests, however. This is intended to happen, but right now, I believe feature development is a little more important (w.r.t deadlines and finals).